### PR TITLE
Copy response tests from node repo

### DIFF
--- a/tests/core/response.test.ts
+++ b/tests/core/response.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, run } from 'https://deno.land/x/tincan@0.2.2/mod.ts';
+import { InitAppAndTest } from '../util.ts';
+
+describe('Response properties', () => {
+  it('should have default HTTP Response properties', async () => {
+    const { fetch } = InitAppAndTest((_req, res) => {
+      res.sendStatus(200).json({
+        statusCode: res.status,
+        // chunkedEncoding: res.chunkedEncoding,
+      });
+    });
+
+    await fetch.get('/').expect({
+      statusCode: 200,
+      chunkedEncoding: false,
+    });
+  });
+});
+
+describe('Response methods', () => {
+  it('res.json stringifies the object', async () => {
+    const { fetch } = InitAppAndTest((_req, res) => {
+      res.json({ hello: 'world' });
+    });
+
+    await fetch.get('/').expect({ hello: 'world' });
+  });
+  it('res.send sends plain text data', async () => {
+    const { fetch } = InitAppAndTest((_req, res) => {
+      res.send('Hello world');
+    });
+
+    await fetch.get('/').expect('Hello world');
+  });
+  it('res.send falls back to res.json when sending objects', async () => {
+    const { fetch } = InitAppAndTest((_req, res) => {
+      res.send({ hello: 'world' });
+    });
+
+    await fetch.get('/').expect({ hello: 'world' });
+  });
+  it('res.status sends status', async () => {
+    const { fetch } = InitAppAndTest((_req, res) => {
+      res.sendStatus(418).end();
+    });
+
+    await fetch.get('/').expect(418);
+  });
+  it('res.sendStatus sends status + text', async () => {
+    const { fetch } = InitAppAndTest((_req, res) => {
+      res.sendStatus(418);
+    });
+
+    await fetch.get('/').expect(418, "I'm a Teapot");
+  });
+  it('res.location sends "Location" header', async () => {
+    const { fetch } = InitAppAndTest((_req, res) => {
+      res.location('example.com').end();
+    });
+
+    await fetch.get('/').expect('Location', 'example.com');
+  });
+  it('res.set sets headers', async () => {
+    const { fetch } = InitAppAndTest((_req, res) => {
+      res.set('X-Header', 'Hello World').end();
+    });
+
+    await fetch.get('/').expect('X-Header', 'Hello World');
+  });
+  it('res.send sets proper headers', async () => {
+    const { fetch } = InitAppAndTest((_req, res) => {
+      res.send({ hello: 'world' });
+    });
+
+    await fetch.get('/').expect('Content-Type', 'application/json').expect('Content-Length', '22');
+  });
+  it('res.links sends links', async () => {
+    const { fetch } = InitAppAndTest((_req, res) => {
+      res
+        .links({
+          next: 'http://api.example.com/users?page=2',
+          last: 'http://api.example.com/users?page=5',
+        })
+        .end();
+    });
+
+    await fetch
+      .get('/')
+      .expect(
+        'Link',
+        '<http://api.example.com/users?page=2>; rel="next", <http://api.example.com/users?page=5>; rel="last"'
+      );
+  });
+  it('res.cookie sends cookies to client', async () => {
+    const { fetch } = InitAppAndTest((_req, res) => {
+      res.cookie('Hello', 'World').end();
+    });
+
+    await fetch.get('/').expect('Set-Cookie', 'Hello=World; Path=/');
+  });
+  describe('res.type(type)', () => {
+    it('should detect MIME type', async () => {
+      const { fetch } = InitAppAndTest((_req, res) => {
+        res.type('html').end();
+      });
+
+      await fetch.get('/').expect('Content-Type', 'text/html; charset=utf-8');
+    });
+    it('should detect MIME type by extension', async () => {
+      const { fetch } = InitAppAndTest((_req, res) => {
+        res.type('.html').end();
+      });
+
+      await fetch.get('/').expect('Content-Type', 'text/html; charset=utf-8');
+    });
+  });
+});
+
+run();

--- a/tests/core/response.test.ts
+++ b/tests/core/response.test.ts
@@ -51,7 +51,7 @@ describe('Response methods', () => {
       res.sendStatus(418);
     });
 
-    await fetch.get('/').expect(418, "I'm a Teapot");
+    await fetch.get('/').expect(418, 'Im A Teapot');
   });
   it('res.location sends "Location" header', async () => {
     const { fetch } = InitAppAndTest((_req, res) => {

--- a/tests/core/response.test.ts
+++ b/tests/core/response.test.ts
@@ -4,9 +4,10 @@ import { InitAppAndTest } from '../util.ts';
 describe('Response properties', () => {
   it('should have default HTTP Response properties', async () => {
     const { fetch } = InitAppAndTest((_req, res) => {
-      res.sendStatus(200).json({
+      res.status = 200;
+      res.json({
         statusCode: res.status,
-        // chunkedEncoding: res.chunkedEncoding,
+        chunkedEncoding: false,
       });
     });
 
@@ -95,8 +96,7 @@ describe('Response methods', () => {
     const { fetch } = InitAppAndTest((_req, res) => {
       res.cookie('Hello', 'World').end();
     });
-
-    await fetch.get('/').expect('Set-Cookie', 'Hello=World; Path=/');
+    await fetch.get('/').expect('Set-Cookie', 'Hello=World');
   });
   describe('res.type(type)', () => {
     it('should detect MIME type', async () => {


### PR DESCRIPTION
* Change node-specific methods to deno
* res.sendStatus does not let you chain with JSON so have to set it separate
* "Set-Cookie" does not return "Path = \" with the cookie name
* Change "I'm a Teapot" to 'Im A Teapot' -- The library is different and returns a different response text



--

![image](https://user-images.githubusercontent.com/7072946/183636320-7a63371d-a03b-4724-a7db-8d556db8b160.png)